### PR TITLE
Quick tweak to lower VOD results in the list

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -36,8 +36,15 @@ class ADEAgent(Agent.Movies):
       # curID = the ID portion of the href in 'movie'
       curID = movie.get('href').split('/',2)[1]
       score = INITIAL_SCORE - Util.LevenshteinDistance(title.lower(), curName.lower())
+
+      #If the category is VOD then lower the score by half to place it lower than DVD results
+      movie2 = movie.xpath('./@category')
+      if len(movie2) > 0:
+        if 'gridviewvod' in movie2[0].lower():
+          score = score / 2
+
       if curName.lower().count(title.lower()):
-        results.Append(MetadataSearchResult(id = curID, name = curName, score = INITIAL_SCORE, lang = lang))
+        results.Append(MetadataSearchResult(id = curID, name = curName, score = score, lang = lang))
       elif (score >= GOOD_SCORE):
         results.Append(MetadataSearchResult(id = curID, name = curName, score = score, lang = lang))
 


### PR DESCRIPTION
Sorry about all of the commit messages from my merging the changes to the repositories, still getting used to Github.  

Anyway if it's a DVD then the score is untouched, but VOD results have the score cut in half so they're always on the bottom.  I've tried adding descriptors to the title, but they're written to the Plex database...  which is very annoying.  No year to pull, this is the only thing I can think of.