### PR TITLE
Added choice of using ProductionYear for older releases, flipped DVD/BR

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -377,16 +377,19 @@ class ADEAgent(Agent.Movies):
             pullscreenscount = 3
         try:
           imgs = html.xpath('//a[contains(@rel, "scenescreenshots")]')
-          screencount = 0
-          imagelist = self.Rand(1,len(imgs),pullscreenscount)
-          if DEBUG: Log('Pulling Screenshot Images: %s' % ', '.join(str(e) for e in imagelist))
-          for img in imgs:
-            screencount += 1
-            if screencount in imagelist:
-              thumbUrl = img.attrib['href']
-              if DEBUG: Log('Writing Screen Image # %s: %s' % (str(screencount), str(thumbUrl)))
-              thumb = HTTP.Request(thumbUrl)
-              metadata.art[thumbUrl] = Proxy.Media(thumb)
+          if len(imgs):
+            screencount = 0
+            imagelist = self.Rand(1,len(imgs),pullscreenscount)
+            if DEBUG: Log('Pulling Screenshot Images: %s' % ', '.join(str(e) for e in imagelist))
+            for img in imgs:
+              screencount += 1
+              if screencount in imagelist:
+                thumbUrl = img.attrib['href']
+                if DEBUG: Log('Writing Screen Image # %s: %s' % (str(screencount), str(thumbUrl)))
+                thumb = HTTP.Request(thumbUrl)
+                metadata.art[thumbUrl] = Proxy.Media(thumb)
+          else:
+            if DEBUG: Log('No Screenshot Images were found for media')
         except Exception, e:
           Log('Got an exception while parsing screenshot images %s' %str(e))
 
@@ -406,16 +409,21 @@ class ADEAgent(Agent.Movies):
           if galleryurl is not None:
             gallery = HTML.ElementFromURL(galleryurl)
             imagelist = gallery.xpath('//div/a[contains(@class, "thumb fancy")]')
-            gallerycount = 0
-            screenlist = self.Rand(1,len(imagelist),pullgallerycount)
-            if DEBUG: Log('Pulling Gallery Images: %s' % ', '.join(str(e) for e in screenlist))
-            for imgs in imagelist:
-              gallerycount += 1
-              if gallerycount in screenlist:
-                imageurl = imgs.attrib['href']
-                if DEBUG: Log('Writing Gallery Image # %s: %s' % (str(gallerycount),str(imageurl)))
-                image = HTTP.Request(imageurl)
-                metadata.art[imageurl] = Proxy.Media(image)
+            if len(imagelist):
+              gallerycount = 0
+              screenlist = self.Rand(1,len(imagelist),pullgallerycount)
+              if DEBUG: Log('Pulling Gallery Images: %s' % ', '.join(str(e) for e in screenlist))
+              for imgs in imagelist:
+                gallerycount += 1
+                if gallerycount in screenlist:
+                  imageurl = imgs.attrib['href']
+                  if DEBUG: Log('Writing Gallery Image # %s: %s' % (str(gallerycount),str(imageurl)))
+                  image = HTTP.Request(imageurl)
+                  metadata.art[imageurl] = Proxy.Media(image)
+            else:
+              if DEBUG: Log('No Gallery Images were found for media')
+          else:
+            if DEBUG: Log('No Gallery was found for media')
         except Exception, e:
             Log('Got an exception while parsing gallery images %s' %str(e))
 

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -36,5 +36,29 @@
     "label":"If the 'Production Year' is less than the 'Release Date Year', then use Production Year instead with Jan 1st appended for the date (YYYY-01-01)",
     "type":"bool",
     "default":"true"
+  },
+  {
+    "id":"pullscreens",
+    "label":"Retrieve Screenshots from Media Page",
+    "type":"bool",
+    "default":"false"
+  },
+  {
+    "id":"pullscreenscount",
+    "label":"Number of Screenshots to pull if enabled",
+    "type":"text",
+    "default":"3"
+  },
+  {
+    "id":"pullgallery",
+    "label":"Retrieve Images from Gallery Page if available",
+    "type":"bool",
+    "default":"false"
+  },
+  {
+    "id":"pullgallerycount",
+    "label":"Number of Gallery Images to pull if enabled",
+    "type":"text",
+    "default":"3"
   }
 ]

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -30,5 +30,11 @@
     "label":"Scoring value to show results over.  Results containing the exact search term will always be shown (The score is an integer value, 100 for perfect match.  98 Default)",
     "type":"text",
     "default":"98"
+  },
+  {
+    "id":"useproductiondate",
+    "label":"If the 'Production Year' is less than the 'Release Date Year', then use Production Year instead with Jan 1st appended for the date (YYYY-01-01)",
+    "type":"bool",
+    "default":"true"
   }
 ]


### PR DESCRIPTION
Added in code requested by russbgrant:  If the "Production Year" is more than a year older than the "Release Date" then build a date from Production Year (YYYY-01-01) and use that instead.  Useful for tagging older items that are being re-released currently.  This is an option in the User Preferences.

Also flipped the ranking of DVD and Blu-Ray since I kept getting posters with that annoying Blu-Ray bar at the top.  The order of precedence is now DVD -> Blu-Ray -> VoD