### PR TITLE
Fix for updated div tags

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -121,10 +121,14 @@ class ADEAgent(Agent.Movies):
           #if len(movie2) > 0:
           #  mediaformat = "br"
 
-          movie2 = movie.xpath('.//a[@title="VOD" or @title="vod"]')
+          movie2 = movie.xpath('.//a[@title="VOD" or @title="vod" or @title="Video On Demand"]')
           if DEBUG: Log('Current title is VOD')
           if len(movie2) > 0:
             mediaformat = "vod"
+          else:
+            # ADE Has made some div tag changes where they have the Video on Demand, but they don't have an "Available: " div tag set for some reason
+            if DEBUG: Log('No Category Found assuming VOD')
+            mediaformat = 'vod'
 
         else:
             mediaformat = 'NA'

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -121,7 +121,7 @@ class ADEAgent(Agent.Movies):
           #if len(movie2) > 0:
           #  mediaformat = "br"
 
-          movie2 = movie.xpath('.//a[@title="VOD" or @title="vod" or @title="Video On Demand"]')
+          movie2 = movie.xpath('.//a[@title="VOD" or @title="vod"]')
           if DEBUG: Log('Current title is VOD')
           if len(movie2) > 0:
             mediaformat = "vod"


### PR DESCRIPTION
Added fallback for titles missing the "Availability: " tag. The titles exist and are vods, but the "vod" category is not rendered on the page or populated in the div tag for that section. Fallback logs when it is triggered.